### PR TITLE
Fix incorrect cardinal count when inserting duplicate keys

### DIFF
--- a/conjuntoAVL.cpp
+++ b/conjuntoAVL.cpp
@@ -84,25 +84,32 @@ bool ConjuntoAVL<T>::pertenece(const T& clave) const {
 
 template <class T>
 void ConjuntoAVL<T>::insertar(const T& clave){
-    if (cardinal() == 0) _raiz = new NodoAVL<T>(clave, nullptr);
-    else {
+    if (cardinal() == 0) {
+        _raiz = new NodoAVL<T>(clave, nullptr);
+        _cardinal++;
+    } else {
         NodoAVL<T> *nodo = _raiz;
         NodoAVL<T> *padre;
         bool agregado = false;
+        bool nuevo = false;
         while (!agregado) {
             padre = nodo;
             bool irIzquierda = clave < nodo->clave;
-            nodo->clave == clave ? agregado = true : agregado = false;
-            nodo = irIzquierda ? nodo->izquierda : nodo->derecha;
-            if (nodo==nullptr && !agregado){
-                irIzquierda ? padre->izquierda = new NodoAVL<T>(clave,padre)
-                            : padre->derecha = new NodoAVL<T>(clave,padre);
-                agregado = true;
-                rebalancear(padre);
+            if (nodo->clave == clave) {
+                agregado = true;  // ya estaba en el arbol
+            } else {
+                nodo = irIzquierda ? nodo->izquierda : nodo->derecha;
+                if (nodo==nullptr){
+                    irIzquierda ? padre->izquierda = new NodoAVL<T>(clave,padre)
+                                : padre->derecha = new NodoAVL<T>(clave,padre);
+                    agregado = true;
+                    nuevo = true;
+                    rebalancear(padre);
+                }
             }
         }
+        if (nuevo) _cardinal++;
     }
-    _cardinal++;
 }
 
 //Hago el borrado del Nodo, verifico si el arbol existe y luego busco el nodo. Si el elemento esta

--- a/diccAVL.cpp
+++ b/diccAVL.cpp
@@ -91,28 +91,33 @@ const T& DiccionarioAVL<T>::obtener(const T &clave) const {
 
 template <class T>
 void DiccionarioAVL<T>::definir(const T& clave, const T& definicion){
-    if (cardinal() == 0) _raiz = new NodoAVL<T>(clave,definicion,nullptr);
-    else {
+    if (cardinal() == 0) {
+        _raiz = new NodoAVL<T>(clave,definicion,nullptr);
+        _cardinal++;
+    } else {
         NodoAVL<T> *nodo = _raiz;
         NodoAVL<T> *padre;
         bool agregado = false;
+        bool nuevo = false;
         while (!agregado) {
             padre = nodo;
             bool irIzquierda = clave < nodo->clave;
             if (nodo->clave == clave) {
                 nodo->definicion = definicion;
-                agregado = true;
-            }
-            nodo = irIzquierda ? nodo->izquierda : nodo->derecha;
-            if (nodo==nullptr && !agregado){
-                irIzquierda ? padre->izquierda = new NodoAVL<T>(clave,definicion,padre)
-                            : padre->derecha = new NodoAVL<T>(clave,definicion,padre);
-                agregado = true;
-                rebalancear(padre);
+                agregado = true;  // ya estaba definida
+            } else {
+                nodo = irIzquierda ? nodo->izquierda : nodo->derecha;
+                if (nodo==nullptr){
+                    irIzquierda ? padre->izquierda = new NodoAVL<T>(clave,definicion,padre)
+                                : padre->derecha = new NodoAVL<T>(clave,definicion,padre);
+                    agregado = true;
+                    nuevo = true;
+                    rebalancear(padre);
+                }
             }
         }
+        if (nuevo) _cardinal++;
     }
-    _cardinal++;
 }
 
 //Hago el borrado del Nodo, verifico si el arbol existe y luego busco el nodo. Si el elemento esta


### PR DESCRIPTION
## Summary
- avoid increasing `_cardinal` when inserting existing elements in `ConjuntoAVL`
- avoid increasing `_cardinal` when redefining existing keys in `DiccionarioAVL`

## Testing
- `g++ -std=c++11 -Wall -Wextra -pedantic -O2 conjuntoAVL.cpp -o test_conjunto`
- `g++ -std=c++11 -Wall -Wextra -pedantic -O2 diccAVL.cpp -o test_dicc`
- `./test_conjunto <<EOF
2
5
2
5
0
99
EOF`
- `./test_dicc <<EOF
2
1
10
2
1
20
0
99
EOF`


------
https://chatgpt.com/codex/tasks/task_e_68405aa7b4988326bce7dca5a8824efe